### PR TITLE
Fixed misleading ES6 mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # babel-sublime-snippets
 
-Sublime snippets for [ES6+ JavaScript](http://kangax.github.io/compat-table/es6/) and [React](http://facebook.github.io/react/docs/component-specs.html).
+Sublime snippets for [React](http://facebook.github.io/react/docs/component-specs.html) in ES5 and [ES6](http://kangax.github.io/compat-table/es6/) flavors.
 
 ## Installation
 
@@ -23,8 +23,6 @@ To set a key binding, go to "Preferences: Key Bindings - User" from the Command 
 ```
 
 ## Available snippets
-
-### ES6
 
 ### React
 


### PR DESCRIPTION
Changes are self explanatory. To avoid any further confusion it might be a good idea to rename package to something like `Babel React Snippets` since Babel is mostly about ES6+ and not React