### PR TITLE
Change React.PropTypes to just PropTypes

### DIFF
--- a/react_propTypes.sublime-snippet
+++ b/react_propTypes.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
     <content><![CDATA[
 propTypes: {
-	${1}: React.PropTypes.${2:string}
+	${1}: PropTypes.${2:string}
 },
 ]]></content>
     <tabTrigger>pt</tabTrigger>

--- a/react_propTypes_arrayInstanceOf.sublime-snippet
+++ b/react_propTypes_arrayInstanceOf.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.arrayOf(React.PropTypes.instanceOf(${2:Class}))${3:.isRequired}$0
+${1}: PropTypes.arrayOf(PropTypes.instanceOf(${2:Class}))${3:.isRequired}$0
 ]]></content>
     <tabTrigger>ptai</tabTrigger>
     <scope>source.js</scope>

--- a/react_propTypes_arrayOf.sublime-snippet
+++ b/react_propTypes_arrayOf.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.arrayOf(${2:propType})${3:.isRequired}$0
+${1}: PropTypes.arrayOf(${2:propType})${3:.isRequired}$0
 ]]></content>
     <tabTrigger>pta</tabTrigger>
     <scope>source.js</scope>

--- a/react_propTypes_bool.sublime-snippet
+++ b/react_propTypes_bool.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.bool${2:.isRequired}$0
+${1}: PropTypes.bool${2:.isRequired}$0
 ]]></content>
     <tabTrigger>ptb</tabTrigger>
     <scope>source.js</scope>

--- a/react_propTypes_element.sublime-snippet
+++ b/react_propTypes_element.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.element${2:.isRequired}$0
+${1}: PropTypes.element${2:.isRequired}$0
 ]]></content>
     <tabTrigger>pte</tabTrigger>
     <scope>source.js</scope>

--- a/react_propTypes_func.sublime-snippet
+++ b/react_propTypes_func.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.func${2:.isRequired}$0
+${1}: PropTypes.func${2:.isRequired}$0
 ]]></content>
     <tabTrigger>ptf</tabTrigger>
     <scope>source.js</scope>

--- a/react_propTypes_instanceOf.sublime-snippet
+++ b/react_propTypes_instanceOf.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.instanceOf(${2:Class})${3:.isRequired}$0
+${1}: PropTypes.instanceOf(${2:Class})${3:.isRequired}$0
 ]]></content>
     <tabTrigger>pti</tabTrigger>
     <scope>source.js</scope>

--- a/react_propTypes_node.sublime-snippet
+++ b/react_propTypes_node.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.node${2:.isRequired}$0
+${1}: PropTypes.node${2:.isRequired}$0
 ]]></content>
     <tabTrigger>ptn</tabTrigger>
     <scope>source.js</scope>

--- a/react_propTypes_number.sublime-snippet
+++ b/react_propTypes_number.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.number${2:.isRequired}$0
+${1}: PropTypes.number${2:.isRequired}$0
 ]]></content>
     <tabTrigger>ptn</tabTrigger>
     <scope>source.js</scope>

--- a/react_propTypes_object.sublime-snippet
+++ b/react_propTypes_object.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.object${2:.isRequired}$0
+${1}: PropTypes.object${2:.isRequired}$0
 ]]></content>
     <tabTrigger>pto</tabTrigger>
     <scope>source.js</scope>

--- a/react_propTypes_objectOf.sublime-snippet
+++ b/react_propTypes_objectOf.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.objectOf(${2:type})${3:.isRequired}$0
+${1}: PropTypes.objectOf(${2:type})${3:.isRequired}$0
 ]]></content>
     <tabTrigger>ptof</tabTrigger>
     <scope>source.js</scope>

--- a/react_propTypes_oneOf.sublime-snippet
+++ b/react_propTypes_oneOf.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.oneOf([${2:value}, ${3:value}])${4:.isRequired}$0
+${1}: PropTypes.oneOf([${2:value}, ${3:value}])${4:.isRequired}$0
 ]]></content>
     <tabTrigger>ptof</tabTrigger>
     <scope>source.js</scope>

--- a/react_propTypes_oneOfType.sublime-snippet
+++ b/react_propTypes_oneOfType.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.oneOfType([${2:value}, ${3:value}])${4:.isRequired}$0
+${1}: PropTypes.oneOfType([${2:value}, ${3:value}])${4:.isRequired}$0
 ]]></content>
     <tabTrigger>ptoft</tabTrigger>
     <scope>source.js</scope>

--- a/react_propTypes_shape.sublime-snippet
+++ b/react_propTypes_shape.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.shape({
+${1}: PropTypes.shape({
   $0
 })
 ]]></content>

--- a/react_propTypes_string.sublime-snippet
+++ b/react_propTypes_string.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-${1}: React.PropTypes.string${2:.isRequired}$0
+${1}: PropTypes.string${2:.isRequired}$0
 ]]></content>
     <tabTrigger>pts</tabTrigger>
     <scope>source.js</scope>


### PR DESCRIPTION
Fix for issue #28, now that React.PropTypes no longer works in React 15.5 or higher.  PropTypes have been moved to their own package.